### PR TITLE
Upgrade loader-utils from 2.0.2 to 2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "bootstrap-scss": "^4.3.1",
         "chart.js": "^2.8.0",
         "history": "^4.10.1",
+        "loader-utils": "^2.0.4",
         "node-sass": "^7.0.3",
         "react": "^16.9.0",
         "react-bootstrap": "^1.0.0-beta.12",
@@ -13084,9 +13085,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -30632,9 +30633,9 @@
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="
     },
     "loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bootstrap-scss": "^4.3.1",
     "chart.js": "^2.8.0",
     "history": "^4.10.1",
+    "loader-utils": "^2.0.4",
     "node-sass": "^7.0.3",
     "react": "^16.9.0",
     "react-bootstrap": "^1.0.0-beta.12",


### PR DESCRIPTION
**Description:** This PR adds implementation to update react boilerplate dependency loader-utils from 2.0.2 to 2.0.4.

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed


**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.