### PR TITLE
Upgrade dependency package qs from 6.5.2 to 6.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "history": "^4.10.1",
         "loader-utils": "^2.0.4",
         "node-sass": "^7.0.3",
+        "qs": "^6.5.3",
         "react": "^16.9.0",
         "react-bootstrap": "^1.0.0-beta.12",
         "react-chartjs-2": "^2.8.0",
@@ -16165,9 +16166,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "engines": {
         "node": ">=0.6"
       }
@@ -32709,9 +32710,9 @@
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
     },
     "querystringify": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "history": "^4.10.1",
     "loader-utils": "^2.0.4",
     "node-sass": "^7.0.3",
+    "qs": "^6.5.3",
     "react": "^16.9.0",
     "react-bootstrap": "^1.0.0-beta.12",
     "react-chartjs-2": "^2.8.0",


### PR DESCRIPTION
**Description:** This PR adds implementation to update react boilerplate dependency qs from 6.5.2 to 6.5.3

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed


**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.